### PR TITLE
fix: enable supplied CharacterModification deletion

### DIFF
--- a/src/backend/src/main/java/datasource/mappers/CharacterModifierMapper.java
+++ b/src/backend/src/main/java/datasource/mappers/CharacterModifierMapper.java
@@ -93,6 +93,33 @@ public class CharacterModifierMapper {
         return false;
     }
 
+    /**
+     * Delete all supplied instances for a particular {@link
+     * CharacterModification}.
+     *
+     * @param <T> The class type of the {@link CharacterModification} supplied
+     * @param type the supplied {@link CharacterModification} {@link
+     *         ModificationType}
+     * @param cm the supplied resource for which this deleteAll is called
+     * @param conn An open {@link Database} connection to queue transactions on
+     * @return true if transaction was successful / occurred, false if otherwise
+     */
+    public <T extends Entity<?> & CharacterModification> boolean deleteAllForSupply(
+        ModificationType type, T cm, Connection conn
+    ) {
+        // Check type of object being cleared
+        String tableName = SUPPLY_TABLES.get(type);
+        if (tableName == null) throw new IllegalStateException("No supply_table is mapped for type " + type);
+
+        String sql = "DELETE FROM " + tableName + " WHERE supply_id = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setLong(1, cm.getId().value());
+            return pstmt.executeUpdate() == 1;
+        } catch (SQLException e) {
+            throw SQLExceptionTranslator.translate(e);
+        }
+    }
+
     /* -------------------- Thin Exposed  Supply Finders -------------------- */
 
     public List<Long> findAsmIds(String kind, long id, Connection conn) {

--- a/src/backend/src/main/java/services/AsmService.java
+++ b/src/backend/src/main/java/services/AsmService.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 
 import datasource.Database;
 import datasource.UnitOfWork;
+import datasource.mappers.CharacterModifierMapper;
 import datasource.mappers.MapperRegistry;
 import datasource.utils.SQLExceptionTranslator;
 import domain.modifiers.AbilityScoreModifier;
+import domain.types.ModificationType;
 
 /**
  * Service layer component for {@link AbilityScoreModifier}, containing all
@@ -106,6 +108,13 @@ public class AsmService extends AbstractService {
 
         // TODO: Lightweight object is fine here, only ID is needed to delete
         UnitOfWork.newCurrent();
+
+        // Deleted supplied instances of CharacterModification first
+        CharacterModifierMapper supplyMapper = new CharacterModifierMapper();
+        UnitOfWork.getCurrent().registerWork(conn ->
+            supplyMapper.deleteAllForSupply(ModificationType.ASM, asm, conn)
+        );
+
         UnitOfWork.getCurrent().registerDeleted(asm);
         return UnitOfWork.getCurrent().commit()
             ? OperationResult.SUCCESS

--- a/src/backend/src/main/java/services/FeatService.java
+++ b/src/backend/src/main/java/services/FeatService.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 
 import datasource.Database;
 import datasource.UnitOfWork;
+import datasource.mappers.CharacterModifierMapper;
 import datasource.mappers.MapperRegistry;
 import datasource.utils.SQLExceptionTranslator;
 import domain.modifiers.Feat;
+import domain.types.ModificationType;
 
 /**
  * Service layer component for {@link Feat}, containing all
@@ -108,6 +110,13 @@ public class FeatService extends AbstractService {
 
         // TODO: Lightweight object is fine here, only ID is needed to delete
         UnitOfWork.newCurrent();
+
+        // Deleted supplied instances of CharacterModification first
+        CharacterModifierMapper supplyMapper = new CharacterModifierMapper();
+        UnitOfWork.getCurrent().registerWork(conn ->
+            supplyMapper.deleteAllForSupply(ModificationType.FEAT, feat, conn)
+        );
+
         UnitOfWork.getCurrent().registerDeleted(feat);
         return UnitOfWork.getCurrent().commit()
             ? OperationResult.SUCCESS

--- a/src/backend/src/main/java/services/LanguageService.java
+++ b/src/backend/src/main/java/services/LanguageService.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 
 import datasource.Database;
 import datasource.UnitOfWork;
+import datasource.mappers.CharacterModifierMapper;
 import datasource.mappers.MapperRegistry;
 import datasource.utils.SQLExceptionTranslator;
 import domain.modifiers.Language;
+import domain.types.ModificationType;
 
 /**
  * Service layer component for {@link Language}, containing all business level
@@ -105,6 +107,13 @@ public class LanguageService extends AbstractService {
 
         // TODO: Lightweight object is fine here, only ID is needed to delete
         UnitOfWork.newCurrent();
+
+        // Deleted supplied instances of CharacterModification first
+        CharacterModifierMapper supplyMapper = new CharacterModifierMapper();
+        UnitOfWork.getCurrent().registerWork(conn ->
+            supplyMapper.deleteAllForSupply(ModificationType.LANGUAGE, language, conn)
+        );
+
         UnitOfWork.getCurrent().registerDeleted(language);
         return UnitOfWork.getCurrent().commit()
             ? OperationResult.SUCCESS

--- a/src/backend/src/main/java/services/ProficiencyService.java
+++ b/src/backend/src/main/java/services/ProficiencyService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import datasource.Database;
 import datasource.UnitOfWork;
+import datasource.mappers.CharacterModifierMapper;
 import datasource.mappers.MapperRegistry;
 import datasource.mappers.proficiency.ProficiencyMapper;
 import datasource.utils.SQLExceptionTranslator;
@@ -15,6 +16,7 @@ import domain.modifiers.proficiency.ArmourProficiency;
 import domain.modifiers.proficiency.Proficiency;
 import domain.modifiers.proficiency.SkillProficiency;
 import domain.modifiers.proficiency.ToolProficiency;
+import domain.types.ModificationType;
 import domain.types.ProficiencyType;
 
 /**
@@ -173,6 +175,13 @@ public class ProficiencyService extends AbstractService {
 
         // TODO: Lightweight object is fine here, only ID is needed to delete
         UnitOfWork.newCurrent();
+
+        // Deleted supplied instances of CharacterModification first
+        CharacterModifierMapper supplyMapper = new CharacterModifierMapper();
+        UnitOfWork.getCurrent().registerWork(conn ->
+            supplyMapper.deleteAllForSupply(ModificationType.PROFICIENCY, proficiency, conn)
+        );
+
         UnitOfWork.getCurrent().registerDeleted(proficiency);
         return UnitOfWork.getCurrent().commit()
             ? OperationResult.SUCCESS


### PR DESCRIPTION
# Summary
Previously, a CharacterModification (e.g. Proficiency) could not be deleted without first unassigning it's allocation to all relevant CharacterModifiers, however which it was assigned to was unclear from DB constraint error message alone. There were two possible (not mutually exclusive) solutions to this issue:

1. Remove CharacterModifications by automatically unassigning them on requested deletion
2. Display a list of CharacterModifiers supplying the modification and have a user manually unassign these

The first option was chosen for this fix, for ease of implementation, however there are plans to also implement this second idea at some point in time - allowing users to reverse search usage locations and displaying warnings before deleting modifications that are in use.

## File changes
- Backend
  - `M` datasource/:
    - mappers/**CharacterModifierMapper** - new `deleteAllForSupply()` method for clearing modification use cases
    - **UnitOfWork** - made optional additional transaction work queueable
  - `M` **services/** - all CharacterModification domain entity services have been updated to utilise this supply clearing
